### PR TITLE
[인증] - 비회원일 경우, 응답헤더에 토큰을 담을 때, NullPointerException이 발생하는 현상 수정

### DIFF
--- a/src/main/java/com/nhnacademy/couponapi/presentation/controller/CouponController.java
+++ b/src/main/java/com/nhnacademy/couponapi/presentation/controller/CouponController.java
@@ -12,13 +12,17 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Date;
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 쿠폰 컨트롤러 클래스입니다.
@@ -61,6 +65,10 @@ public class CouponController {
             @Parameter(description = "도서 ID", required = true) @RequestParam Long bookId,
             @Parameter(description = "카테고리 ID 목록", required = true) @RequestParam List<Long> categoryIds,
             @CurrentUser JwtUserDetails jwtUserDetails) {
+        if (Objects.isNull(jwtUserDetails)) {
+            return ResponseEntity.ok(couponService.getAllByBookIdAndCategoryIds(bookId, categoryIds));
+        }
+
         return ResponseEntity.ok()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUserDetails.accessToken())
                 .header("Refresh-Token", jwtUserDetails.refreshToken())


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [x] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 비회원일 경우, 토큰이 없어 응답 헤더에 토큰을 담아줄때 NullPointerException이 발생하는 현상 수정했습니다.
- 현재 도서 상세 페이지 조회 시, 회원 비회원 구분없이 쿠폰을 조회하고 있습니다. 현재 코드는 바로 응답헤더에 토큰을 담아주도록 구현해서 발생한 것으로 보입니다.
- 우선, 비회원일 경우는 별도로 헤더에 담지 않도록 수정했습니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->